### PR TITLE
:bug: Fix password reset bug

### DIFF
--- a/src/Services/Production/AuthenticatableService.php
+++ b/src/Services/Production/AuthenticatableService.php
@@ -151,7 +151,7 @@ class AuthenticatableService extends BaseService implements AuthenticatableServi
             return false;
         }
         $this->authenticatableRepository->update($user, ['password' => $password]);
-        $this->passwordResettableRepository->delete($token);
+        $this->passwordResettableRepository->delete($user);
         $this->setUser($user);
 
         return true;


### PR DESCRIPTION
Fix bug
```
FatalThrowableError in DatabaseTokenRepository.php line 148:
Type error: Argument 1 passed to Illuminate\Auth\Passwords\DatabaseTokenRepository::delete() must implement interface Illuminate\Contracts\Auth\CanResetPassword, string given, called in /Users/XXX/vendor/laravel-rocket/foundation/src/Services/Production/AuthenticatableService.php on line 154
```