### PR TITLE
Fix: Skip custom parser for multipart/form-data in PUT/PATCH requests

### DIFF
--- a/src/Http/Requests/APIRequest.php
+++ b/src/Http/Requests/APIRequest.php
@@ -122,6 +122,12 @@ class APIRequest extends Request
     {
         $methods = ['PUT', 'PATCH'];
 
+        // Don't use a custom parser for multipart/form-data - Laravel handles these correctly
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+        if (str_starts_with($contentType, 'multipart/form-data')) {
+            return false;
+        }
+
         return app()->environment() !== 'testing' && in_array($_SERVER['REQUEST_METHOD'], $methods);
     }
 


### PR DESCRIPTION
Laravel handles multipart/form-data correctly, so the custom Restful parser should not be used for these requests to avoid parsing issues.

This pull request makes a targeted improvement to the request parsing logic in `APIRequest`. It ensures that multipart form data is handled by Laravel's built-in parser, preventing custom parsing for these requests.

Request parsing improvements:

* Updated the `needParser` method in `APIRequest` to skip custom parsing when the request's `CONTENT_TYPE` is `multipart/form-data`, allowing Laravel to handle these requests correctly.